### PR TITLE
Pre-Install git, Update VSTS-Agent to new version 2.142.1  

### DIFF
--- a/initbuildagent.ps1
+++ b/initbuildagent.ps1
@@ -40,6 +40,10 @@ Import-Module -Name navcontainerhelper -DisableNameChecking
 Install-module DockerMsftProvider -Force
 Install-Package -Name docker -ProviderName DockerMsftProvider -Force
 
+# Install Choco & GIT
+Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+choco install -y git
+
 $DownloadFolder = "C:\Download"
 MkDir $DownloadFolder -ErrorAction Ignore | Out-Null
 $agentFilename = "vsts-agent-win-x64-2.141.1.zip"

--- a/initbuildagent.ps1
+++ b/initbuildagent.ps1
@@ -46,9 +46,9 @@ choco install -y git
 
 $DownloadFolder = "C:\Download"
 MkDir $DownloadFolder -ErrorAction Ignore | Out-Null
-$agentFilename = "vsts-agent-win-x64-2.141.1.zip"
+$agentFilename = "vsts-agent-win-x64-2.142.1.zip"
 $agentFullname = Join-Path $DownloadFolder $agentFilename
-$agentUrl = "https://vstsagentpackage.azureedge.net/agent/2.141.1/$agentFilename"
+$agentUrl = "https://vstsagentpackage.azureedge.net/agent/2.142.1/$agentFilename"
 Download-File -sourceUrl $agentUrl -destinationFile $agentFullname
 $agentFolder = "C:\Agent"
 mkdir $agentFolder -ErrorAction Ignore | Out-Null


### PR DESCRIPTION
- added installation of [Git](https://stackoverflow.com/questions/46731433/how-to-download-and-install-git-client-for-window-using-powershell) by using  [Choco](https://chocolatey.org/install)
- Version of VSTS Agent updatet to v2.142.1

I have added these lines of Code to `initbuildagent.ps1`:

```PowerShell
# Install Choco & GIT
Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
choco install -y git
```