### PR TITLE
max vmname length set to 15 chars

### DIFF
--- a/buildagent.json
+++ b/buildagent.json
@@ -6,6 +6,7 @@
             "type": "string",
 			"defaultValue": "",
             "minLength": 3,
+            "maxLength": 15,            
             "metadata": {
                 "Description": "Select the name of the deployment"
             }


### PR DESCRIPTION
max vmname length set to 15 chars, to respect the azure limitation for vm-names