### PR TITLE
switch landing page to /landing instead of :8180

### DIFF
--- a/Default.aspx
+++ b/Default.aspx
@@ -38,7 +38,7 @@ private string createQrImg(string link, string title, int width = 100, int heigh
 private string getLandingPageUrl()
 {
   if (isTraefikUsed())
-    return getHostname() + ":8180";
+    return getHostname() + "/landing";
   else
     return getHostname();
 }

--- a/SetupDesktop.ps1
+++ b/SetupDesktop.ps1
@@ -76,7 +76,7 @@ if ($disableVsCodeUpdate) {
 
 Log "Creating Desktop Shortcuts"
 if ($AddTraefik -eq "Yes") {
-    $landingPageUrl = "http://${publicDnsName}:8180"
+    $landingPageUrl = "http://${publicDnsName}/landing"
 }
 else {
     $landingPageUrl = "http://${publicDnsName}"

--- a/SetupVm.ps1
+++ b/SetupVm.ps1
@@ -184,7 +184,7 @@ New-Item $winPsFolder -ItemType Directory -Force -ErrorAction Ignore | Out-Null
 
 Log "Adding Landing Page to Startup Group"
 if ($AddTraefik -eq "Yes") {
-    $landingPageUrl = "http://${publicDnsName}:8180"
+    $landingPageUrl = "http://${publicDnsName}/landing"
 }
 else {
     $landingPageUrl = "http://${publicDnsName}"

--- a/bcsandboxazure.json
+++ b/bcsandboxazure.json
@@ -504,20 +504,6 @@
                             "priority": 260,
                             "direction": "Inbound"
                         }
-                    },
-                    {
-                        "name": "Log",
-                        "properties": {
-                            "description": "Access to status log if Traefik is used",
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "8180",
-                            "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 270,
-                            "direction": "Inbound"
-                        }
                     }
                 ]
             }

--- a/bcsandboxazureext.json
+++ b/bcsandboxazureext.json
@@ -595,20 +595,6 @@
                             "priority": 260,
                             "direction": "Inbound"
                         }
-                    },
-                    {
-                        "name": "Log",
-                        "properties": {
-                            "description": "Access to status log if Traefik is used",
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "8180",
-                            "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 270,
-                            "direction": "Inbound"
-                        }
                     }
                 ]
             }

--- a/getbc.json
+++ b/getbc.json
@@ -198,7 +198,7 @@
             "defaultValue": "No",
             "allowedValues": [ "Yes", "No" ],
             "metadata": {
-                "Description": "Add traefik.io as reverse proxy. When using traefik, you will find the landing page on http://publicdnsname:8180."
+                "Description": "Add traefik.io as reverse proxy. When using traefik, you will find the landing page on https://publicdnsname/landing."
             }
         }
     },
@@ -504,20 +504,6 @@
                             "destinationAddressPrefix": "*",
                             "access": "Allow",
                             "priority": 260,
-                            "direction": "Inbound"
-                        }
-                    },
-                    {
-                        "name": "Log",
-                        "properties": {
-                            "description": "Access to status log if Traefik is used",
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "8180",
-                            "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 270,
                             "direction": "Inbound"
                         }
                     }

--- a/getbcext.json
+++ b/getbcext.json
@@ -628,20 +628,6 @@
                             "priority": 260,
                             "direction": "Inbound"
                         }
-                    },
-                    {
-                        "name": "Log",
-                        "properties": {
-                            "description": "Access to status log if Traefik is used",
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "8180",
-                            "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 270,
-                            "direction": "Inbound"
-                        }
                     }
                 ]
             }

--- a/getnav.json
+++ b/getnav.json
@@ -497,20 +497,6 @@
                             "priority": 260,
                             "direction": "Inbound"
                         }
-                    },
-                    {
-                        "name": "Log",
-                        "properties": {
-                            "description": "Access to status log if Traefik is used",
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "8180",
-                            "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 270,
-                            "direction": "Inbound"
-                        }
                     }
                 ]
             }

--- a/getnavext.json
+++ b/getnavext.json
@@ -602,20 +602,6 @@
                             "priority": 260,
                             "direction": "Inbound"
                         }
-                    },
-                    {
-                        "name": "Log",
-                        "properties": {
-                            "description": "Access to status log if Traefik is used",
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "8180",
-                            "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 270,
-                            "direction": "Inbound"
-                        }
                     }
                 ]
             }

--- a/status.aspx
+++ b/status.aspx
@@ -13,7 +13,7 @@ private string getHostname()
 private string getLandingPageUrl()
 {
   if (isTraefikUsed())
-    return getHostname() + ":8180";
+    return getHostname() + "/landing";
   else
     return getHostname();
 }


### PR DESCRIPTION
Instead of using the unusual port of 8180 which lessens discoverability and increases complexity, use /landing on standard port 443. Works in connection with https://github.com/microsoft/navcontainerhelper/pull/485