### PR TITLE
Updated stale link to ex-MS employee's repo

### DIFF
--- a/CleanupAfterDocker.ps1
+++ b/CleanupAfterDocker.ps1
@@ -52,7 +52,7 @@ stop-service docker
 Write-Host "Downloading Docker-Ci-Zap"
 $dockerCiZapExe = Join-Path $Env:TEMP "docker-ci-zap.exe"
 Remove-Item $dockerCiZapExe -Force -ErrorAction Ignore
-(New-Object System.Net.WebClient).DownloadFile("https://github.com/jhowardmsft/docker-ci-zap/raw/master/docker-ci-zap.exe", $dockerCiZapExe)
+(New-Object System.Net.WebClient).DownloadFile("https://github.com/moby/docker-ci-zap/raw/master/docker-ci-zap.exe", $dockerCiZapExe)
 Unblock-File -Path $dockerCiZapExe
 
 Write-Host "Running Docker-Ci-Zap on $dockerRootDir"


### PR DESCRIPTION
The repo referenced in this file for getting the docker-ci-zap tool is still pointing to an old account, which has been taken over by a security researcher and has a pseudo-malicious version of the app living there (it just pings their server when someone uses the tool and passes over environment variables).  The correct repo is updated in this PR.

Please update this as it isn't the correct application and although isn't malicious, it could have been!