### PR TITLE
Add authentication to web status page

### DIFF
--- a/initialize.ps1
+++ b/initialize.ps1
@@ -219,7 +219,7 @@ if (!(Get-Module powershellget | Where-Object { $_.Version -ge [version]"2.2.5" 
 
 AddToStatus "Installing Internet Information Server (this might take a few minutes)"
 if ($WindowsInstallationType -eq "Server") {
-    Add-WindowsFeature Web-Server,web-Asp-Net45,Web-Basic-Auth
+    Add-WindowsFeature Web-Server,web-Asp-Net45,Web-Basic-Auth | Out-Null
 } else {
     Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServer,IIS-ASPNET45,IIS-BasicAuthentication -All -NoRestart | Out-Null
 }

--- a/initialize.ps1
+++ b/initialize.ps1
@@ -219,9 +219,9 @@ if (!(Get-Module powershellget | Where-Object { $_.Version -ge [version]"2.2.5" 
 
 AddToStatus "Installing Internet Information Server (this might take a few minutes)"
 if ($WindowsInstallationType -eq "Server") {
-    Add-WindowsFeature Web-Server,web-Asp-Net45
+    Add-WindowsFeature Web-Server,web-Asp-Net45,Web-Basic-Auth
 } else {
-    Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServer,IIS-ASPNET45 -All -NoRestart | Out-Null
+    Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServer,IIS-ASPNET45,IIS-BasicAuthentication -All -NoRestart | Out-Null
 }
 
 Remove-Item -Path "C:\inetpub\wwwroot\iisstart.*" -Force

--- a/initialize.ps1
+++ b/initialize.ps1
@@ -223,10 +223,6 @@ if ($WindowsInstallationType -eq "Server") {
 } else {
     Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServer,IIS-ASPNET45,IIS-BasicAuthentication -All -NoRestart | Out-Null
 }
-AddToStatus "Installing IIS URL Rewrite module"
-$urlRewriteInstaller = "c:\myfolder\rewrite_amd64.msi"
-Download-File -sourceUrl "https://download.microsoft.com/download/1/2/8/128E2E22-C1B9-44A4-BE2A-5859ED1D4592/rewrite_amd64_en-US.msi" -destinationFile $urlRewriteInstaller
-Start-Process -FilePath msiexec.exe -ArgumentList "/i `"$urlRewriteInstaller`" /quiet /norestart" -Wait
 
 Remove-Item -Path "C:\inetpub\wwwroot\iisstart.*" -Force
 Download-File -sourceUrl "$($scriptPath)Default.aspx"            -destinationFile "C:\inetpub\wwwroot\default.aspx"

--- a/initialize.ps1
+++ b/initialize.ps1
@@ -223,6 +223,10 @@ if ($WindowsInstallationType -eq "Server") {
 } else {
     Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServer,IIS-ASPNET45,IIS-BasicAuthentication -All -NoRestart | Out-Null
 }
+AddToStatus "Installing IIS URL Rewrite module"
+$urlRewriteInstaller = "c:\myfolder\rewrite_amd64.msi"
+Download-File -sourceUrl "https://download.microsoft.com/download/1/2/8/128E2E22-C1B9-44A4-BE2A-5859ED1D4592/rewrite_amd64_en-US.msi" -destinationFile $urlRewriteInstaller
+Start-Process -FilePath msiexec.exe -ArgumentList "/i `"$urlRewriteInstaller`" /quiet /norestart" -Wait
 
 Remove-Item -Path "C:\inetpub\wwwroot\iisstart.*" -Force
 Download-File -sourceUrl "$($scriptPath)Default.aspx"            -destinationFile "C:\inetpub\wwwroot\default.aspx"

--- a/web.config
+++ b/web.config
@@ -6,7 +6,6 @@
           <anonymousAuthentication enabled="false" />
           <basicAuthentication enabled="true" />
         </authentication>
-        <access sslFlags="Ssl" />
       </security>
     </system.webServer>
   </location>
@@ -17,7 +16,6 @@
           <anonymousAuthentication enabled="false" />
           <basicAuthentication enabled="true" />
         </authentication>
-        <access sslFlags="Ssl" />
       </security>
     </system.webServer>
   </location>
@@ -28,7 +26,6 @@
           <anonymousAuthentication enabled="false" />
           <basicAuthentication enabled="true" />
         </authentication>
-        <access sslFlags="Ssl" />
       </security>
     </system.webServer>
   </location>

--- a/web.config
+++ b/web.config
@@ -1,6 +1,12 @@
 ﻿<configuration>
   <location path=".">
     <system.webServer>
+      <security>
+        <authentication>
+          <anonymousAuthentication enabled="false" />
+          <basicAuthentication enabled="true" />
+        </authentication>
+      </security>
       <httpProtocol>
         <customHeaders>
           <add name="X-Content-Type-Options" value="nosniff" />

--- a/web.config
+++ b/web.config
@@ -1,22 +1,47 @@
 ﻿<configuration>
-  <location path=".">
+  <location path="default.aspx">
     <system.webServer>
       <security>
         <authentication>
           <anonymousAuthentication enabled="false" />
           <basicAuthentication enabled="true" />
         </authentication>
+        <access sslFlags="Ssl" />
       </security>
-      <httpProtocol>
-        <customHeaders>
-          <add name="X-Content-Type-Options" value="nosniff" />
-        </customHeaders>
-        </httpProtocol>
-        <staticContent>
-          <mimeMap fileExtension=".*" mimeType="application/octet-stream" />
-          <mimeMap fileExtension="." mimeType="text/plain" />
-        </staticContent>
-      <directoryBrowse enabled="false" />
     </system.webServer>
   </location>
+  <location path="status.aspx">
+    <system.webServer>
+      <security>
+        <authentication>
+          <anonymousAuthentication enabled="false" />
+          <basicAuthentication enabled="true" />
+        </authentication>
+        <access sslFlags="Ssl" />
+      </security>
+    </system.webServer>
+  </location>
+  <location path="request.aspx">
+    <system.webServer>
+      <security>
+        <authentication>
+          <anonymousAuthentication enabled="false" />
+          <basicAuthentication enabled="true" />
+        </authentication>
+        <access sslFlags="Ssl" />
+      </security>
+    </system.webServer>
+  </location>
+  <system.webServer>
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Content-Type-Options" value="nosniff" />
+      </customHeaders>
+      </httpProtocol>
+      <staticContent>
+        <mimeMap fileExtension=".*" mimeType="application/octet-stream" />
+        <mimeMap fileExtension="." mimeType="text/plain" />
+      </staticContent>
+    <directoryBrowse enabled="false" />
+  </system.webServer>
 </configuration>

--- a/web.config
+++ b/web.config
@@ -7,29 +7,16 @@
           <basicAuthentication enabled="true" />
         </authentication>
       </security>
+      <httpProtocol>
+        <customHeaders>
+          <add name="X-Content-Type-Options" value="nosniff" />
+        </customHeaders>
+      </httpProtocol>
+      <staticContent>
+        <mimeMap fileExtension=".*" mimeType="application/octet-stream" />
+        <mimeMap fileExtension="." mimeType="text/plain" />
+      </staticContent>
+      <directoryBrowse enabled="false" />
     </system.webServer>
   </location>
-  <system.webServer>
-    <httpProtocol>
-      <customHeaders>
-        <add name="X-Content-Type-Options" value="nosniff" />
-      </customHeaders>
-    </httpProtocol>
-    <staticContent>
-      <mimeMap fileExtension=".*" mimeType="application/octet-stream" />
-      <mimeMap fileExtension="." mimeType="text/plain" />
-    </staticContent>
-    <directoryBrowse enabled="false" />
-    <rewrite>
-      <rules>
-        <rule name="HTTP to HTTPS redirect" stopProcessing="true">
-          <match url="(.*)" />
-          <conditions>
-            <add input="{HTTPS}" pattern="^OFF$" />
-          </conditions>
-          <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" redirectType="Permanent" />
-        </rule>
-      </rules>
-    </rewrite>
-  </system.webServer>
 </configuration>

--- a/web.config
+++ b/web.config
@@ -1,25 +1,5 @@
 ﻿<configuration>
-  <location path="default.aspx">
-    <system.webServer>
-      <security>
-        <authentication>
-          <anonymousAuthentication enabled="false" />
-          <basicAuthentication enabled="true" />
-        </authentication>
-      </security>
-    </system.webServer>
-  </location>
-  <location path="status.aspx">
-    <system.webServer>
-      <security>
-        <authentication>
-          <anonymousAuthentication enabled="false" />
-          <basicAuthentication enabled="true" />
-        </authentication>
-      </security>
-    </system.webServer>
-  </location>
-  <location path="request.aspx">
+  <location path=".">
     <system.webServer>
       <security>
         <authentication>
@@ -34,11 +14,22 @@
       <customHeaders>
         <add name="X-Content-Type-Options" value="nosniff" />
       </customHeaders>
-      </httpProtocol>
-      <staticContent>
-        <mimeMap fileExtension=".*" mimeType="application/octet-stream" />
-        <mimeMap fileExtension="." mimeType="text/plain" />
-      </staticContent>
+    </httpProtocol>
+    <staticContent>
+      <mimeMap fileExtension=".*" mimeType="application/octet-stream" />
+      <mimeMap fileExtension="." mimeType="text/plain" />
+    </staticContent>
     <directoryBrowse enabled="false" />
+    <rewrite>
+      <rules>
+        <rule name="HTTP to HTTPS redirect" stopProcessing="true">
+          <match url="(.*)" />
+          <conditions>
+            <add input="{HTTPS}" pattern="^OFF$" />
+          </conditions>
+          <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" redirectType="Permanent" />
+        </rule>
+      </rules>
+    </rewrite>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
## Summary

Enables IIS Basic Authentication on the web status page (`status.aspx`, `default.aspx`, etc.) so that access requires valid VM admin credentials.

## Changes

- **`web.config`** — Disables anonymous authentication and enables basic authentication via a `<security>` section.
- **`initialize.ps1`** — Installs the IIS Basic Authentication feature (`Web-Basic-Auth` / `IIS-BasicAuthentication`) alongside the existing IIS setup.

## How it works

IIS Basic Auth validates against local Windows accounts on the VM. Users authenticate with the same `vmAdminUsername` / `adminPassword` credentials specified during ARM template deployment — no additional user provisioning needed.

## Note

Basic Authentication transmits credentials in base64 encoding. Deployments using Let's Encrypt (via `ContactEMailForLetsEncrypt` parameter) will protect credentials over HTTPS.