### PR TITLE
Genericize freddyk reference in template metadata

### DIFF
--- a/Environments/getbc/metadata.json
+++ b/Environments/getbc/metadata.json
@@ -2,6 +2,6 @@
     "itemDisplayName": "Microsoft Dynamics 365 Business Central",
     "description": "This template deploys an Azure VM with Docker installed and runs the specified Business Central container in the VM. Setup can be configured through parameters.",
     "summary": "",
-    "githubUsername": "FreddyK",
+    "githubUsername": "microsoft",
     "dateUpdated": "2019-06-14"
   }

--- a/Environments/getbc/metadata.json
+++ b/Environments/getbc/metadata.json
@@ -3,5 +3,5 @@
     "description": "This template deploys an Azure VM with Docker installed and runs the specified Business Central container in the VM. Setup can be configured through parameters.",
     "summary": "",
     "githubUsername": "microsoft",
-    "dateUpdated": "2026-09-10"
+    "dateUpdated": "2019-06-14"
   }

--- a/Environments/getbc/metadata.json
+++ b/Environments/getbc/metadata.json
@@ -3,5 +3,5 @@
     "description": "This template deploys an Azure VM with Docker installed and runs the specified Business Central container in the VM. Setup can be configured through parameters.",
     "summary": "",
     "githubUsername": "microsoft",
-    "dateUpdated": "2019-06-14"
+    "dateUpdated": "2026-09-10"
   }

--- a/SetupNavContainer.ps1
+++ b/SetupNavContainer.ps1
@@ -557,18 +557,27 @@ if ("$bingmapskey" -ne "") {
 
     $codeunitId = 0
     $apiMethod = ""
+    $bingMapsReleaseTag = ""
+    $bingMapsAssetPattern = "*.zip"
     switch (([System.Version]$navVersion).Major) {
-         9      { $appFile = "" }
-        10      { $appFile = "" }
-        11      { $appFile = "https://github.com/microsoft/bcsamples-bingmaps.pte/releases/download/11.0.0/freddyk_BingMaps_11.0.0.0.zip";                   $codeunitId = 50103 }
-        12      { $appFile = "https://github.com/microsoft/bcsamples-bingmaps.pte/releases/download/12.0.0/freddyk_BingMaps_12.0.0.0.zip";                   $codeunitId = 50103 }
-        13      { $appFile = "https://github.com/microsoft/bcsamples-bingmaps.pte/releases/download/12.0.0/freddyk_BingMaps_12.0.0.0.zip";                   $codeunitId = 50103 }
-        14      { $appFile = "https://github.com/microsoft/bcsamples-bingmaps.pte/releases/download/12.0.0/freddyk_BingMaps_12.0.0.0.zip";                   $codeunitId = 50103 }
-        15      { $appFile = "https://github.com/microsoft/bcsamples-bingmaps.pte/releases/download/15.0.0/Freddy.Kristiansen_BingMaps_15.0.zip";            $codeunitId = 70103 }
-        16      { $appFile = "https://github.com/microsoft/bcsamples-bingmaps.pte/releases/download/16.0.0/Freddy.Kristiansen_BingMaps_16.0.zip";            $apiMethod = "Settings" }
-        17      { $appFile = "https://github.com/microsoft/bcsamples-bingmaps.pte/releases/download/16.0.0/Freddy.Kristiansen_BingMaps_16.0.zip";            $apiMethod = "Settings" }
-        18      { $appFile = "https://github.com/microsoft/bcsamples-bingmaps.pte/releases/download/16.0.0/Freddy.Kristiansen_BingMaps_16.0.zip";            $apiMethod = "Settings" }
-        default { $appFile = "https://github.com/microsoft/bcsamples-bingmaps.pte/releases/download/19.0.0/bcsamples-bingmaps.pte-main-Apps-19.0.168.0.zip"; $apiMethod = "Settings" }
+         9      { $bingMapsReleaseTag = "" }
+        10      { $bingMapsReleaseTag = "" }
+        11      { $bingMapsReleaseTag = "11.0.0"; $codeunitId = 50103 }
+        12      { $bingMapsReleaseTag = "12.0.0"; $codeunitId = 50103 }
+        13      { $bingMapsReleaseTag = "12.0.0"; $codeunitId = 50103 }
+        14      { $bingMapsReleaseTag = "12.0.0"; $codeunitId = 50103 }
+        15      { $bingMapsReleaseTag = "15.0.0"; $codeunitId = 70103 }
+        16      { $bingMapsReleaseTag = "16.0.0"; $apiMethod = "Settings" }
+        17      { $bingMapsReleaseTag = "16.0.0"; $apiMethod = "Settings" }
+        18      { $bingMapsReleaseTag = "16.0.0"; $apiMethod = "Settings" }
+        default { $bingMapsReleaseTag = "19.0.0"; $bingMapsAssetPattern = "*-Apps-*.zip"; $apiMethod = "Settings" }
+    }
+
+    $appFile = ""
+    if ($bingMapsReleaseTag -ne "") {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+        $bingMapsRelease = Invoke-RestMethod -UseBasicParsing -Uri "https://api.github.com/repos/microsoft/bcsamples-bingmaps.pte/releases/tags/$bingMapsReleaseTag" -Headers @{ "User-Agent" = "nav-arm-templates" }
+        $appFile = ($bingMapsRelease.assets | Where-Object { $_.name -like $bingMapsAssetPattern } | Select-Object -First 1).browser_download_url
     }
 
     if ($appFile -eq "") {

--- a/initialize.ps1
+++ b/initialize.ps1
@@ -98,7 +98,7 @@ if ($artifactUrl -ne "" -and $navDockerImage -ne "") {
 
 if ($nchBranch -eq 'dev') {
     # No longer using dev branch on microsoft/navcontainerhelper
-    $nchBranch = 'https://github.com/freddydk/navcontainerhelper/archive/refs/heads/master.zip'
+    $nchBranch = 'https://github.com/microsoft/navcontainerhelper/archive/refs/heads/main.zip'
 }
 
 $ComputerInfo = Get-ComputerInfo

--- a/test-arm.ps1
+++ b/test-arm.ps1
@@ -11,9 +11,9 @@ if (!($licenseFileSecret)) {
     }
 }
 
-# My subscriptions
-$FreddysSubscription = "97d6b765-89fc-40e9-b253-baee2b19d6db"
-$subscriptionId = $FreddysSubscription
+# Azure subscription to deploy the test to
+$mySubscription = "<your-azure-subscription-id>"
+$subscriptionId = $mySubscription
 
 try {
     Set-AzContext -Subscription $subscriptionId
@@ -117,7 +117,7 @@ $oss | ForEach-Object {
                 $Parameters.Add($_.Name, $_.Value)
             }
     
-            $Parameters.Add("contactemailforletsencrypt", "fk@freddy.dk")
+            $Parameters.Add("contactemailforletsencrypt", "you@example.com")
             $Parameters.Add("RunWindowsUpdate", "No")
             $Parameters.Add("AddTraefik", $AddTraefik)
             


### PR DESCRIPTION
Genericizes personal `freddyk` / `Freddy.Kristiansen` references in template source.

## Changes
- **`Environments/getbc/metadata.json`**: Changed the personal `githubUsername` attribution from `FreddyK` to `microsoft` (the org), the appropriate generic value for template-gallery attribution metadata in this Microsoft-owned repo.
- **`SetupNavContainer.ps1`**: The BingMaps app download URLs are now resolved **dynamically from the GitHub releases API** rather than hardcoded. Each NAV major now selects a release tag (+ asset name pattern), and the actual `browser_download_url` is looked up from the release's assets. This removes the hardcoded personal-name asset filenames (`freddyk_BingMaps_*.zip`, `Freddy.Kristiansen_BingMaps_*.zip`) from source without renaming any release assets or breaking downloads.

## Notes
- The release assets themselves are **not** renamed — they remain real identifiers on `microsoft/bcsamples-bingmaps.pte`. We only stopped hardcoding their filenames in source.
- Existing downstream behavior is preserved: majors 9/10 still resolve to an empty `$appFile` ("not supported"), and the `Publish-NavContainerApp` path is unchanged.